### PR TITLE
Create a specific user to access the S3 bucket #5

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -46,10 +46,9 @@ if [[ "${s3}" =~ minio* ]]; then
   s3_password=$(ynh_string_random -l 32)
   s3_user=$app
 
-  # FIXME: this script, if finally used, is only available starting with a certain version.
-  # We should abort the installation if MinIO is below the version that ships this script.
-  # PR: https://github.com/YunoHost-Apps/minio_ynh/pull/77
-  sudo -u minio "$minio_install_dir/setup_app_bucket.sh" --app="$app" --secret="$s3_password" --with-versioning
+  # FIXME: this script is currently in PR for the MinIO app:
+  # https://github.com/YunoHost-Apps/minio_ynh/pull/77
+  sudo -u minio "../sources/setup_app_bucket.sh" --app="$app" --secret="$s3_password" --with-versioning
 
   ynh_app_setting_set --key="s3_domain" --value="$s3_domain"
   ynh_app_setting_set --key="s3_user" --value="$s3_user"

--- a/sources/setup_app_bucket.sh
+++ b/sources/setup_app_bucket.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -eEu -o pipefail
+
+if [ "$(whoami)" != "minio" ]; then
+  sudo -u minio "$0" "$@"
+  exit $?
+fi
+
+mb_opts=()
+help=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --app=*) APP="${1#*=}"; shift 1;;
+    --secret=*) SECRET="${1#*=}"; shift 1;;
+    --with-versioning) mb_opts+=("--with-versioning"); shift 1;;
+    --help*) help=1; shift 1;;
+
+    *) echo "unknown option: $1" >&2; exit 1;;
+  esac
+done
+
+if [ "$help" == "1" ]; then
+  echo "Usage: $0 --app=\$app --secret=YOUR_SECRET [--with-versioning]"
+  echo ""
+  echo "Set up a MinIO bucket for apps. Meant to be used by packages."
+  echo "Also creates an access key in MinIO who will be granted readwrite access only to this bucket."
+  echo "See the admin documentation for more info: https://github.com/YunoHost-Apps/minio_ynh/blob/master/doc/ADMIN.md"
+  exit 0
+fi
+
+if [ -z "${APP:-}" ]; then
+  echo "Please pass the following mandatory argument: --app=\$app" >&2
+  exit 1
+fi
+
+if [ -z "${SECRET:-}" ]; then
+  echo 'Please pass the following mandatory argument: --secret="YOUR_SECRET"' >&2
+  exit 1
+fi
+
+ACCESS_KEY=$APP
+BUCKET=$APP
+
+policy_file=$(mktemp --suffix=".$APP.policy.json")
+minio_install_dir=/var/www/minio
+
+cleanup() {
+  rv=$?
+  rm -f "$policy_file"
+  exit $rv
+}
+
+trap "cleanup" EXIT
+
+if "$minio_install_dir/mc" ls --json minio/ | jq -r ".key" | grep -q "^$APP/$"; then
+  echo "Bucket already exist, skip"
+  exit 0
+fi
+
+# Create a bucket in S3 for the app
+"$minio_install_dir/mc" mb "${mb_opts[@]}" "minio/$BUCKET"
+
+# Create a new policy to give only access to the app's bucket
+# The policy_file is temporary and will be cleaned up at the end of the execution
+cat <<EOF > "$policy_file"
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [ "s3:*" ],
+    "Resource": [
+      "arn:aws:s3:::$BUCKET/*",
+      "arn:aws:s3:::$BUCKET"
+    ]
+  }]
+}
+EOF
+
+# Create the access for the app to the bucket, with the above policy.
+"$minio_install_dir/mc" admin accesskey create minio/ --access-key "$ACCESS_KEY" --secret-key "$SECRET" --policy "$policy_file" \
+  --name "$APP-ynh" --description "Access key for the $APP package for Yunohost"


### PR DESCRIPTION
## Problem

- See #5 

## Solution

- Create a PR to add a script that creates and gives access to the app's bucket only: https://github.com/YunoHost-Apps/minio_ynh/pull/77
- Use this script

Currently in draft as it requires another PR to be merged first.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
