### PR TITLE
Fix collaboration does not work when using IPv6 #17

### DIFF
--- a/conf/systemd-yprovider.service
+++ b/conf/systemd-yprovider.service
@@ -8,6 +8,7 @@ User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/src/frontend/servers/y-provider
 EnvironmentFile=__INSTALL_DIR__/.env_yjs
+Environment="PATH=__PATH_WITH_NODEJS__"
 ExecStart=yarn start
 StandardOutput=append:/var/log/__APP__/__APP__-yprovider.log
 StandardError=inherit


### PR DESCRIPTION
## Problem

Fixes #17 

## Solution

Old versions of nodejs suffered from this bug: https://github.com/nodejs/node/issues/48846

Which seems to cause the issue reported in #17 

Taking a look at what nodejs version is loaded, it looks like one has to modify the PATH env variable to add nodejs: https://github.com/YunoHost/yunohost/blob/92a516b280ecff3f3a7adee429c7a99d11993efb/helpers/helpers.v2.1.d/nodejs#L65

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
