### PR TITLE
fix: workaround for Next.js SIGILL error while building

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -101,7 +101,11 @@ popd
 
 pushd "$install_dir/src/frontend"
   ynh_hide_warnings ynh_exec_as_app yarn install
-  ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn app:build
+  ynh_hide_warnings ynh_exec_as_app yarn next telemetry disable
+popd
+
+pushd "$install_dir/src/frontend/apps/impress"
+  ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn next build --no-lint
   mv ./apps/impress/out "$install_dir/_build/frontend"
 popd
 

--- a/scripts/install
+++ b/scripts/install
@@ -102,10 +102,9 @@ popd
 pushd "$install_dir/src/frontend"
   ynh_hide_warnings ynh_exec_as_app yarn install
   ynh_hide_warnings ynh_exec_as_app yarn next telemetry disable
-popd
-
-pushd "$install_dir/src/frontend/apps/impress"
-  ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn next build --no-lint
+  pushd "./apps/impress"
+    ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn next build --no-lint
+  popd
   mv ./apps/impress/out "$install_dir/_build/frontend"
 popd
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -91,10 +91,10 @@ popd
 
 pushd "$install_dir/src/frontend"
   ynh_hide_warnings ynh_exec_as_app yarn install
-popd
-
-pushd "$install_dir/src/frontend/apps/impress"
-  ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn next build --no-lint
+  ynh_hide_warnings ynh_exec_as_app yarn next telemetry disable
+  pushd "./apps/impress"
+    ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn next build --no-lint
+  popd
   mv ./apps/impress/out "$install_dir/_build/frontend"
 popd
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -91,7 +91,10 @@ popd
 
 pushd "$install_dir/src/frontend"
   ynh_hide_warnings ynh_exec_as_app yarn install
-  ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn app:build
+popd
+
+pushd "$install_dir/src/frontend/apps/impress"
+  ynh_hide_warnings ynh_exec_as_app NODE_ENV=production yarn next build --no-lint
   mv ./apps/impress/out "$install_dir/_build/frontend"
 popd
 


### PR DESCRIPTION
## Problem

 - Docs does not build on RPI4 (#18) 
 - Docs build process is quite slow

## Solution

 - Don't run code linting, formating (prettier), etc.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
