### PR TITLE
Fix linting issue nginx

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -55,7 +55,7 @@ location /media/ {
   proxy_pass https://__S3_DOMAIN__/__APP__/;
   proxy_set_header Host __S3_DOMAIN__;
 
-  add_header Content-Security-Policy "default-src 'none'" always;
+  add_header Content-Security-Policy "default-src 'none'";
 }
 
 location /media-auth {


### PR DESCRIPTION
## Problem

- The CI reports an linting error:
> Do not use 'add_header' in the NGINX conf. Use 'more_set_headers' instead. (See https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx and https://github.com/openresty/headers-more-nginx-module#more_set_headers )

## Solution

- Use `more_set_headers` instead

- [x] ⚠️ Need manual testing of attachments before merging

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
