### PR TITLE
minio: Cleanup access key when key already exists

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -20,6 +20,10 @@ ynh_redis_remove_db "$celery_redis_db"
 
 ynh_nodejs_remove
 
+ynh_script_progression "Unregistering minio accesskey"
+access_key=${app//_/-}
+"/var/www/minio/mc" admin accesskey remove minio/ "$access_key"
+
 ynh_config_remove_logrotate
 
 # Remove the service from the list of services known by YunoHost (added from `yunohost service add`)


### PR DESCRIPTION
## Problem

- When uninstalling and reinstalling the app, we can't be sure of the existing accesskey.

## Solution

- This is meant to be sure that the accesskey is the one generated by the app.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
